### PR TITLE
Add a configuration option to disable the doublequote replacement behavior

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -4,3 +4,4 @@
  */
 
 $conf['overwrite'] = 1;
+$conf['doublequotes'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -4,3 +4,4 @@
  */
 
 $meta['overwrite'] = array('onoff');
+$meta['doublequotes'] = array('onoff');

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -6,3 +6,4 @@
  * @author Tim Weinhold <tim.weinhold@gmail.com>
  */
 $lang['overwrite']             = 'Coresyntax überschreiben?';
+$lang['doublequotes']          = 'Alternative ("") Syntax aktivieren?';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -3,4 +3,5 @@
  * English language file for config
  */
 
-$lang['overwrite'] = 'Overwrite core syntax?';
+$lang['overwrite']             = 'Overwrite core syntax?';
+$lang['doublequotes']          = 'Enable alternative ("") syntax?';

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -7,3 +7,4 @@
  * @author Schplurtz le Déboulonné <schplurtz@laposte.net>
  */
 $lang['overwrite']             = 'Remplacer la syntaxe originale ?';
+$lang['doublequotes']          = 'Activer la syntaxe alternative ("") ?';

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -6,3 +6,4 @@
  * @author Hideaki SAWADA <sawadakun@live.jp>
  */
 $lang['overwrite']             = '本体の構文を置換えますか？';
+$lang['doublequotes']          = '代替構文（""）を有効にしますか？';

--- a/lang/ko/settings.php
+++ b/lang/ko/settings.php
@@ -6,3 +6,4 @@
  * @author Myeongjin <aranet100@gmail.com>
  */
 $lang['overwrite']             = '코어 문법을 덮어쓰겠습니까?';
+$lang['doublequotes']          = '대체 구문 ("")을 사용 하시겠습니까?';

--- a/lang/nl/settings.php
+++ b/lang/nl/settings.php
@@ -6,3 +6,4 @@
  * @author Rene <wllywlnt@yahoo.com>
  */
 $lang['overwrite']             = 'Overschrijf de centrale syntax?';
+$lang['doublequotes']          = 'Alternatieve ("") syntaxis inschakelen?';

--- a/lang/no/settings.php
+++ b/lang/no/settings.php
@@ -6,3 +6,4 @@
  * @author Arne Hanssen <arne.hanssen@getmail.no>
  */
 $lang['overwrite']             = 'Overskrive standard-syntaks?';
+$lang['doublequotes']          = 'Aktiver alternativ ("") syntaks?';

--- a/lang/ru/settings.php
+++ b/lang/ru/settings.php
@@ -6,3 +6,4 @@
  * @author Aleksandr Selivanov <alexgearbox@yandex.ru>
  */
 $lang['overwrite']             = 'Переписать основной синтаксис?';
+$lang['doublequotes']          = 'Включить альтернативный синтаксис ("")?'

--- a/syntax.php
+++ b/syntax.php
@@ -30,13 +30,17 @@ class syntax_plugin_unformattedcode extends DokuWiki_Syntax_Plugin {
      * Connect pattern to lexer
      */
     function connectTo($mode) {
-        $this->Lexer->addEntryPattern('\x22\x22(?=.*\x22\x22)',$mode,'plugin_unformattedcode'); // ""code""
+        if ($this->getConf('doublequotes')) {
+            $this->Lexer->addEntryPattern('\x22\x22(?=.*\x22\x22)',$mode,'plugin_unformattedcode'); // ""code""
+        }
         if ($this->getConf('overwrite')) {
             $this->Lexer->addEntryPattern('\x27\x27(?=.*\x27\x27)',$mode,'plugin_unformattedcode'); // ''code''
         }
     }
     function postConnect() {
-        $this->Lexer->addExitPattern('\x22\x22', 'plugin_unformattedcode');
+        if ($this->getConf('doublequotes')) {
+            $this->Lexer->addExitPattern('\x22\x22', 'plugin_unformattedcode');
+        }
         if ($this->getConf('overwrite')) {
             $this->Lexer->addExitPattern('\x27\x27', 'plugin_unformattedcode');
         }


### PR DESCRIPTION
This was undesirable because sometimes quotes just pile up. (For example, Python's """ docstrings).

Default keeps the current behavior.

I used Google Translate (both directions) for the localizations. I'm least confident in the Korean translation. The rest I'm reasonably confident are understandable given the number of cognates.